### PR TITLE
Add `register-token` to the blender-cli

### DIFF
--- a/blender-cli/README.md
+++ b/blender-cli/README.md
@@ -41,7 +41,21 @@ cargo run --release -- --seed //Alice set-node ws://127.0.0.1:9943
 cargo run --release -- --seed //Alice set-contract-address <blender-addrs>
 ```
 
+### Register new PSP22 token contract with Blender instance
+
+> This step is not required if you're working with local chain and had successfuly ran `./setup_blending.sh`
+
+Before using Blender contract to deposit/withdraw tokens, we need to first "register" the PSP22 token contract in our Blender instance. Without this action, any transactions calling `deposit`/`withdraw` will fail.
+
+**NOTE:** Token IDs in Blender instance have to be unique so if your transaction gets front-runned by someone else, trying to register under same `--token-id` you will have to retry the txn with a new token ID value.
+
+```bash
+cargo run --release -- --seed //Alice register-token --token-id 0 --token-address <PSP22_token_contract_address>
+```
+
 ### Deposit a note
+
+> Assumes that you've successfuly completed previous step of registering a PSP token under `--token-id 0` and that you had approved allowance of that PSP token to the Blender contract. Either manually or via `./setup_blending.sh`.
 
 Deposits a note of 50 tokens of a PSP token registered with an id 0:
 

--- a/blender-cli/blender-metadata.json
+++ b/blender-cli/blender-metadata.json
@@ -1,8 +1,8 @@
 {
   "source": {
-    "hash": "0xcf57f05ba80fb6161a12261068734bc64148ebcb42241352efcf9019c4e2d007",
+    "hash": "0x519a049d23c6b344b7cca40c1d44b4f182ba41a2a6b6bc300a02db23431ad049",
     "language": "ink! 3.4.0",
-    "compiler": "rustc 1.65.0-nightly"
+    "compiler": "rustc 1.67.0-nightly"
   },
   "contract": {
     "name": "blender",
@@ -149,6 +149,34 @@
           ],
           "docs": [],
           "label": "Withdrawn"
+        },
+        {
+          "args": [
+            {
+              "docs": [],
+              "indexed": true,
+              "label": "token_id",
+              "type": {
+                "displayName": [
+                  "TokenId"
+                ],
+                "type": 11
+              }
+            },
+            {
+              "docs": [],
+              "indexed": false,
+              "label": "token_address",
+              "type": {
+                "displayName": [
+                  "AccountId"
+                ],
+                "type": 12
+              }
+            }
+          ],
+          "docs": [],
+          "label": "TokenRegistered"
         }
       ],
       "messages": [

--- a/blender-cli/src/config.rs
+++ b/blender-cli/src/config.rs
@@ -47,6 +47,7 @@ pub(super) enum StateReadCommand {
 pub(super) enum ContractInteractionCommand {
     Deposit(DepositCmd),
     Withdraw(WithdrawCmd),
+    RegisterToken(RegisterTokenCmd),
 }
 
 impl ContractInteractionCommand {
@@ -58,6 +59,9 @@ impl ContractInteractionCommand {
             ContractInteractionCommand::Withdraw(WithdrawCmd { metadata_file, .. }) => {
                 metadata_file.clone()
             }
+            ContractInteractionCommand::RegisterToken(RegisterTokenCmd {
+                metadata_file, ..
+            }) => metadata_file.clone(),
         }
     }
 }
@@ -130,6 +134,21 @@ pub(super) struct WithdrawCmd {
     /// raw pk bytes file.
     #[clap(default_value = "withdraw.pk.bytes", value_parser = parsing::parse_path)]
     pub proving_key_file: PathBuf,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Args)]
+pub(super) struct RegisterTokenCmd {
+    /// Token ID to register this particular token contract under.
+    #[clap(long)]
+    pub token_id: u16,
+
+    /// Address where the token contract can be found.
+    #[clap(long)]
+    pub token_address: AccountId,
+
+    /// Contract metadata file.
+    #[clap(long, default_value = "blender-metadata.json", value_parser = parsing::parse_path)]
+    pub metadata_file: PathBuf,
 }
 
 mod parsing {

--- a/blender-cli/src/contract.rs
+++ b/blender-cli/src/contract.rs
@@ -265,10 +265,10 @@ impl Blender {
             );
         });
 
-        let _ = self
+        self
             .contract
             .contract_exec(
-                &connection,
+                connection,
                 "register_new_token",
                 &[&token_id.to_string(), &token_address_copy.to_string()],
             )
@@ -280,7 +280,7 @@ impl Blender {
         thread::sleep(Duration::from_secs(3));
         cancel_tx.send(()).unwrap();
 
-        if let Ok(_) = signal_rx.try_recv() {
+        if signal_rx.try_recv().is_ok() {
             println!(
                 "Successfuly registered ${:?} token contract under {:?} token id",
                 &token_address_copy, &token_id

--- a/blender-cli/src/contract.rs
+++ b/blender-cli/src/contract.rs
@@ -265,8 +265,7 @@ impl Blender {
             );
         });
 
-        self
-            .contract
+        self.contract
             .contract_exec(
                 connection,
                 "register_new_token",

--- a/blender-cli/src/contract.rs
+++ b/blender-cli/src/contract.rs
@@ -8,7 +8,7 @@ use std::{
 use aleph_client::{
     contract::{
         event::{listen_contract_events, subscribe_events, ContractEvent},
-        util::to_u128,
+        util::{to_account_id, to_u128},
         ContractInstance,
     },
     AccountId, SignedConnection,
@@ -225,6 +225,69 @@ impl Blender {
                 None => None,
             },
             _ => panic!("Expected {:?} to be a Tuple", &value),
+        }
+    }
+
+    pub fn register_new_token(
+        &self,
+        connection: &SignedConnection,
+        token_id: u16,
+        token_address: AccountId,
+    ) -> Result<()> {
+        let subscription = subscribe_events(connection)?;
+        let (cancel_tx, cancel_rx) = channel();
+        let (signal_tx, signal_rx) = channel::<()>();
+
+        let contract_ptr = self.contract.clone();
+
+        let token_address_copy = token_address.clone();
+
+        thread::spawn(move || {
+            listen_contract_events(
+                subscription,
+                &[&contract_ptr],
+                Some(cancel_rx),
+                |event_or_error| {
+                    println!("{:?}", event_or_error);
+                    if let Ok(ContractEvent { ident, data, .. }) = event_or_error {
+                        if Some(String::from("TokenRegistered")) == ident {
+                            let event_token_id = data.get("token_id").unwrap().clone();
+                            let event_token_address = data.get("token_address").unwrap().clone();
+
+                            if (to_u128(event_token_id).unwrap() as u16) == token_id
+                                && to_account_id(event_token_address).unwrap() == token_address
+                            {
+                                signal_tx.send(()).unwrap()
+                            }
+                        }
+                    }
+                },
+            );
+        });
+
+        let _ = self
+            .contract
+            .contract_exec(
+                &connection,
+                "register_new_token",
+                &[&token_id.to_string(), &token_address_copy.to_string()],
+            )
+            .map_err(|e| {
+                cancel_tx.send(()).unwrap();
+                e
+            })?;
+
+        thread::sleep(Duration::from_secs(3));
+        cancel_tx.send(()).unwrap();
+
+        if let Ok(_) = signal_rx.try_recv() {
+            println!(
+                "Successfuly registered ${:?} token contract under {:?} token id",
+                &token_address_copy, &token_id
+            );
+            Ok(())
+        } else {
+            Err(anyhow!("Failed to observe expected event."))
         }
     }
 }

--- a/blender-cli/src/main.rs
+++ b/blender-cli/src/main.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use house_snark::{MerklePath, MerkleRoot, Note, Nullifier, TokenAmount, TokenId, Trapdoor};
 use inquire::Password;
 use zeroize::Zeroize;
-use ContractInteractionCommand::{Deposit, Withdraw};
+use ContractInteractionCommand::{Deposit, RegisterToken, Withdraw};
 use StateReadCommand::{PrintState, ShowAssets};
 use StateWriteCommand::{SetContractAddress, SetNode};
 
@@ -72,6 +72,9 @@ fn perform_contract_action(
     match command {
         Deposit(cmd) => do_deposit(contract, connection, cmd, app_state)?,
         Withdraw(cmd) => do_withdraw(contract, connection, cmd, app_state)?,
+        RegisterToken(cmd) => {
+            contract.register_new_token(&connection, cmd.token_id, cmd.token_address)?
+        }
     };
     Ok(())
 }


### PR DESCRIPTION
Adds `register-token` command to the `blender-cli`. Simplifies the interaction with Blender contract.

Updates `blender-metadata.json` file to reflect the changes made to the contract. Requires merging https://github.com/Cardinal-Cryptography/aleph-node/pull/761 first.